### PR TITLE
[Modify] 메인페이지 크기 조절 및 푸터 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,10 @@
   <body>
     <header data-include-path="/src/pages/components/header.html"></header>
     <div data-include-path="/src/pages/components/sidebar.html"></div>
-    <div class="main-wraper">
-      <div class="banner relative h-auto">
+    <div class="main-wraper overflow-x-hidden">
+      <div
+        class="banner relative left-1/2 min-w-[1920px] max-w-[1920px] translate-x-[-50%]"
+      >
         <div class="swiper swiper-container">
           <ul class="swiper-wrapper">
             <li class="swiper-slide">
@@ -49,14 +51,14 @@
             </li>
           </ul>
         </div>
-        <div class="absolute left-[300px] top-40 z-10">
+        <div class="absolute left-[18%] top-40 z-10">
           <img
             class="swiper-prev"
             src="src/assets/svg/arrow-circle.svg"
             alt="이전 버튼"
           />
         </div>
-        <div class="absolute right-[300px] top-40 z-10">
+        <div class="absolute right-[18%] top-40 z-10">
           <img
             class="swiper-next"
             src="src/assets/svg/arrowReverse.svg"
@@ -65,8 +67,8 @@
         </div>
       </div>
       <section>
-        <div class="relative mx-auto h-auto w-innerWrapper">
-          <div class="mb-7 mt-10 flex flex-col items-center">
+        <div class="relative mx-auto w-innerWrapper">
+          <div class="mb-10 mt-[52px] flex flex-col items-center">
             <h3 class="text-xl font-bold">이 상품 어때요?</h3>
           </div>
           <div class="swiper swiper-product w-innerWrapper">
@@ -83,7 +85,7 @@
         </div>
       </section>
 
-      <section class="mx-auto w-innerWrapper">
+      <section class="mx-auto w-innerWrapper py-16">
         <img
           src="/src/assets/images/line-banner.jpg"
           alt="더 풍성해진 10월의 퍼플위크"
@@ -92,7 +94,7 @@
 
       <section class="mb-10">
         <div class="relative mx-auto h-auto w-innerWrapper">
-          <div class="mb-7 mt-10 flex flex-col items-center">
+          <div class="mb-10 mt-[52px] flex flex-col items-center">
             <h3 class="text-xl font-bold">놓치면 후회할 가격</h3>
           </div>
 

--- a/src/pages/components/footer.html
+++ b/src/pages/components/footer.html
@@ -53,12 +53,12 @@
     <div>
       <nav>
         <ul class="flex gap-x-3 text-p-base">
-          <li>칼리 소개</li>
-          <li>칼리 소개 영상</li>
-          <li>인재 채용</li>
-          <li>이용약관</li>
-          <li>개인정보처리방침</li>
-          <li>이용안내</li>
+          <li><a href="#">칼리 소개</a></li>
+          <li><a href="#">칼리 소개 영상</a></li>
+          <li><a href="#">인재 채용</a></li>
+          <li><a href="#">이용약관</a></li>
+          <li><a href="#">개인정보처리방침</a></li>
+          <li><a href="#">이용안내</a></li>
         </ul>
       </nav>
       <address class="my-7 text-p-sm not-italic">
@@ -258,6 +258,8 @@
       당사자가 아닙니다. 칼리는 해당 상품의 주문, 품질, 교환/환불 등 의무와
       책임을 부담하지 않습니다.
     </p>
-    <small class="mt-2 capitalize"> karly corp. all rights reserved</small>
+    <small class="mt-2 capitalize"
+      >&copy; karly corp. all rights reserved</small
+    >
   </div>
 </footer>


### PR DESCRIPTION
## PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] config 파일 변경
<br />

## PR 체크리스트
<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)

<br />

### PR 내용 요약
- 메인페이지 배너 크기, 섹션 간격 조절
- 푸터 a태그 추가, copyright 기호 추가

<br />

### PR 상세
- 뷰포트가 줄어들면, 메인페이지 swiper를 사용한 배너의 높이가 줄어드는 문제 해결
- 메인페이지 섹션 간 마진 조절
- 푸터 navigation에 누락된 a태그 추가
- 푸터 하단 copyright 기호 추가

<br />

### 스크린샷
* 뷰포트를 줄였을 때 메인페이지 배너

|기존|수정 후|
|---|---|
|![image](https://github.com/FRONTENDSCHOOL8/pocket-karly/assets/148831765/6775c7fc-141e-4ba2-8d38-224334780806)|![image](https://github.com/FRONTENDSCHOOL8/pocket-karly/assets/148831765/8fcb7ec9-97b6-4f56-9be7-8dd39989cb13)|


<br />

## 이슈
<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->
